### PR TITLE
Add dashboard and monthly upgrades

### DIFF
--- a/index.php
+++ b/index.php
@@ -13,6 +13,7 @@ $payoffF = async_get_card_payoff_plan($user_id);
 $accountsF = async_get_accounts($user_id);
 $balancesF = async_get_all_balances($user_id);
 $recentF = async_get_transactions($user_id, $thisMonth, null, 6);
+$upcomingF = async_get_upcoming_recurring($user_id, 7);
 
 $summary = $summaryF->await();
 $score = $scoreF->await();
@@ -23,6 +24,7 @@ list($totals, $computed, $banks) = $balancesF->await();
 $categories = $summary['categories'];
 $biggest_cat = $summary['biggest'];
 $recent = $recentF->await();
+$upcoming = $upcomingF->await();
 
 // For Chart.js
 $cat_labels = json_encode(array_keys($categories));
@@ -159,6 +161,26 @@ body.dark-mode .big-cat { background:#1e293b; color:#fbbf24;}
         </div>
       </div>
     </div>
+  </div>
+
+  <!-- Upcoming Recurring Transactions -->
+  <div class="glass mb-4">
+    <h5 class="fw-bold mb-3">Upcoming Recurring</h5>
+    <?php if(count($upcoming)): ?>
+    <ul class="mb-0 list-unstyled">
+      <?php foreach($upcoming as $u): ?>
+      <li>
+        <span class="me-2 fw-bold"><?= htmlspecialchars($u['date']) ?></span>
+        <span class="me-2"><?= htmlspecialchars($u['description']) ?></span>
+        <span class="<?= $u['type']=='income' ? 'text-success' : 'text-danger' ?> fw-bold">
+          <?= $u['type']=='income' ? '+' : '-' ?><?= number_format($u['amount'],2) ?>€
+        </span>
+      </li>
+      <?php endforeach; ?>
+    </ul>
+    <?php else: ?>
+    <p class="text-muted mb-0">No upcoming recurring transactions.</p>
+    <?php endif; ?>
   </div>
 
   <!-- Financial Advisor Widget -->

--- a/monthly.php
+++ b/monthly.php
@@ -91,6 +91,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         delete_transaction($_SESSION['user_id'], $_POST['id']);
         header("Location: monthly.php?month=$thisMonth&bank_id=$filter_bank"); exit;
     }
+    if (isset($_POST['duplicate_trans'])) {
+        duplicate_transaction($_SESSION['user_id'], $_POST['id']);
+        header("Location: monthly.php?month=$thisMonth&bank_id=$filter_bank"); exit;
+    }
 }
 ?>
 <!DOCTYPE html>
@@ -308,8 +312,12 @@ body.dark-mode .table tbody tr:hover {
       <?php endif; ?>
     </form>
 
+    <div class="mb-3">
+      <input type="text" id="searchInput" class="form-control" placeholder="Search description...">
+    </div>
+
     <div class="table-responsive">
-      <table class="table align-middle">
+      <table class="table align-middle" id="transTable">
         <thead>
           <tr>
             <th>Date</th>
@@ -319,6 +327,7 @@ body.dark-mode .table tbody tr:hover {
             <th>Account</th>
             <th>Status</th>
             <th>Edit</th>
+            <th>Copy</th>
             <th>Delete</th>
           </tr>
         </thead>
@@ -354,6 +363,12 @@ body.dark-mode .table tbody tr:hover {
                 data-bs-toggle="modal"
                 data-bs-target="#editModal"
                 >Edit</button>
+            </td>
+            <td>
+              <form method="post" style="display:inline">
+                <input type="hidden" name="id" value="<?= $tr['id'] ?>" />
+                <button type="submit" name="duplicate_trans" class="btn btn-sm btn-secondary">Copy</button>
+              </form>
             </td>
             <td>
               <form method="post" style="display:inline" onsubmit="return confirm('Delete this transaction?')">
@@ -497,6 +512,15 @@ editModal.addEventListener('show.bs.modal', event => {
   document.getElementById('edit-type').value = button.getAttribute('data-type');
   document.getElementById('edit-bank').value = button.getAttribute('data-bank') || "";
   document.getElementById('edit-inbal').checked = button.getAttribute('data-inbal') == "1";
+});
+
+// search filter
+document.getElementById('searchInput').addEventListener('input', function(){
+  let q = this.value.toLowerCase();
+  document.querySelectorAll('#transTable tbody tr').forEach(tr => {
+    let desc = tr.children[1].textContent.toLowerCase();
+    tr.style.display = desc.includes(q) ? '' : 'none';
+  });
 });
 
 if(localStorage.getItem('darkMode')==='1'){

--- a/navbar.php
+++ b/navbar.php
@@ -31,6 +31,7 @@ function nav_active($file) { global $page; return $page == $file ? "active" : ""
         <button class="btn btn-outline-secondary btn-sm" title="Notifications (coming soon)" style="pointer-events:none;opacity:.7;">
           <i class="bi bi-bell"></i>
         </button>
+        <button class="btn btn-outline-secondary btn-sm" id="darkToggle" title="Toggle dark mode">🌙</button>
         <div class="dropdown">
           <a class="d-flex align-items-center text-decoration-none dropdown-toggle user-dropdown" href="#" id="dropdownUser" role="button" data-bs-toggle="dropdown" aria-expanded="false">
             <span class="user-avatar"><?= $user ? strtoupper(substr($user['username'],0,1)) : '?' ?></span>
@@ -245,6 +246,13 @@ document.addEventListener('DOMContentLoaded', function(){
     document.body.classList.add('dark-mode');
   } else {
     document.body.classList.remove('dark-mode');
+  }
+  var btn = document.getElementById('darkToggle');
+  if(btn){
+    btn.addEventListener('click', function(){
+      var active = document.body.classList.toggle('dark-mode');
+      localStorage.setItem('darkMode', active ? '1' : '0');
+    });
   }
 });
 </script>


### PR DESCRIPTION
## Summary
- implement helper to get upcoming recurring payments and copy a transaction
- show upcoming recurring items on the dashboard
- allow duplicating transactions and client-side search on monthly page
- add dark‑mode toggle button in navbar

## Testing
- `php -l functions.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e92be81208322b41a4ae18c558782