### PR TITLE
Fix summary warnings and add pending stats

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -280,9 +280,21 @@ function get_monthly_summary($uid, $month = null) {
         'Home'=>0.0, 'Groceries'=>0.0, 'Fun'=>0.0, 'Transport'=>0.0, 'Health'=>0.0, 'Other'=>0.0
     ];
     $income = 0; $expense = 0; $net = 0;
+    $pending = 0; $scheduled = 0; $overdue = 0;
+    $today = strtotime(date('Y-m-d'));
     foreach ($transactions as $tr) {
         $isInBal = $tr['already_in_balance']==1;
         $isReflected = !$isInBal;
+        $trDate = strtotime($tr['date']);
+        // Track scheduling status for transactions not already in starting balance
+        if (!$isInBal) {
+            if ($trDate > $today) {
+                $scheduled++;
+            } else {
+                $pending++;
+                if ($trDate < $today) $overdue++;
+            }
+        }
         // Categories (for reflected only)
         if ($isReflected && $tr['type']=='expense') {
             $cat = categorize($tr['description']);
@@ -303,6 +315,9 @@ function get_monthly_summary($uid, $month = null) {
         'income'=>$income,
         'expense'=>$expense,
         'net'=>$net,
+        'pending'=>$pending,
+        'scheduled'=>$scheduled,
+        'overdue'=>$overdue,
     ];
 }
 

--- a/index.php
+++ b/index.php
@@ -105,11 +105,11 @@ body.dark-mode .big-cat { background:#1e293b; color:#fbbf24;}
         </div>
         <div class="mb-2">
           <span class="fw-bold">Pending:</span>
-          <span class="pending-chip"><?= $summary['pending'] ?></span>
+          <span class="pending-chip"><?= $summary['pending'] ?? 0 ?></span>
           <span class="fw-bold ms-3">Scheduled:</span>
-          <span class="sched-chip"><?= $summary['scheduled'] ?></span>
+          <span class="sched-chip"><?= $summary['scheduled'] ?? 0 ?></span>
           <span class="fw-bold ms-3">Overdue:</span>
-          <span class="od-chip"><?= $summary['overdue'] ?></span>
+          <span class="od-chip"><?= $summary['overdue'] ?? 0 ?></span>
         </div>
         <div class="tiny-tip mt-2">Click “Add Transaction” to resolve pending/overdue.</div>
       </div>


### PR DESCRIPTION
## Summary
- extend `get_monthly_summary` to calculate `pending`, `scheduled` and `overdue`
- expose new values for dashboard
- guard against missing summary keys on index

## Testing
- `php -l functions.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e94cff4508322a88784d2b3c4fe62